### PR TITLE
Create pages for Interest Groups #59

### DIFF
--- a/public/assets/InterestGroups/arvr.svg
+++ b/public/assets/InterestGroups/arvr.svg
@@ -1,0 +1,33 @@
+<svg width="400" height="250" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="arvrGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#d946ef;stop-opacity:1" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <rect width="400" height="250" fill="url(#arvrGrad)" rx="16"/>
+  
+  <circle cx="80" cy="125" r="120" fill="rgba(255,255,255,0.1)"/>
+  <circle cx="320" cy="200" r="80" fill="rgba(255,255,255,0.08)"/>
+  
+  <g transform="translate(200, 100)" filter="url(#glow)">
+    <rect x="-30" y="-12" width="60" height="24" rx="5" fill="white" opacity="0.9"/>
+    <circle cx="-15" cy="0" r="8" fill="url(#arvrGrad)"/>
+    <circle cx="15" cy="0" r="8" fill="url(#arvrGrad)"/>
+    <path d="M-30,0 L-35,8" stroke="white" stroke-width="3" stroke-linecap="round"/>
+    <path d="M30,0 L35,8" stroke="white" stroke-width="3" stroke-linecap="round"/>
+    <rect x="-3" y="-15" width="6" height="6" fill="white" opacity="0.9"/>
+  </g>
+  
+  <text x="200" y="165" font-family="Arial, sans-serif" font-size="36" font-weight="700" fill="white" text-anchor="middle" filter="url(#glow)">AR/VR</text>
+  
+  <text x="200" y="190" font-family="Arial, sans-serif" font-size="14" font-weight="500" fill="rgba(255,255,255,0.9)" text-anchor="middle">µLearn</text>
+</svg>

--- a/public/assets/InterestGroups/cloud.svg
+++ b/public/assets/InterestGroups/cloud.svg
@@ -1,0 +1,31 @@
+<svg width="400" height="250" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="cloudGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0ea5e9;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#4f46e5;stop-opacity:1" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <rect width="400" height="250" fill="url(#cloudGrad)" rx="16"/>
+  
+  <circle cx="80" cy="125" r="120" fill="rgba(255,255,255,0.1)"/>
+  <circle cx="320" cy="200" r="80" fill="rgba(255,255,255,0.08)"/>
+  
+  <g transform="translate(200, 100)" filter="url(#glow)">
+    <ellipse cx="-10" cy="0" rx="12" ry="10" fill="white" opacity="0.9"/>
+    <ellipse cx="10" cy="0" rx="12" ry="10" fill="white" opacity="0.9"/>
+    <ellipse cx="0" cy="-8" rx="15" ry="12" fill="white" opacity="0.9"/>
+    <path d="M-20,0 Q-20,15 0,15 Q20,15 20,0" fill="white" opacity="0.9"/>
+  </g>
+  
+  <text x="200" y="165" font-family="Arial, sans-serif" font-size="26" font-weight="700" fill="white" text-anchor="middle" filter="url(#glow)">Cloud and DevOps</text>
+  
+  <text x="200" y="190" font-family="Arial, sans-serif" font-size="14" font-weight="500" fill="rgba(255,255,255,0.9)" text-anchor="middle">µLearn</text>
+</svg>

--- a/public/assets/InterestGroups/cyber.svg
+++ b/public/assets/InterestGroups/cyber.svg
@@ -1,0 +1,30 @@
+<svg width="400" height="250" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="cyberGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#14b8a6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#0e7490;stop-opacity:1" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <rect width="400" height="250" fill="url(#cyberGrad)" rx="16"/>
+  
+  <circle cx="80" cy="125" r="120" fill="rgba(255,255,255,0.1)"/>
+  <circle cx="320" cy="200" r="80" fill="rgba(255,255,255,0.08)"/>
+  
+  <g transform="translate(200, 95)" filter="url(#glow)">
+    <path d="M0,-25 L-20,-15 L-20,5 Q-20,20 0,30 Q20,20 20,5 L20,-15 Z" fill="white" opacity="0.9"/>
+    <rect x="-8" y="0" width="16" height="18" rx="2" fill="url(#cyberGrad)"/>
+    <circle cx="0" cy="-5" r="7" fill="none" stroke="url(#cyberGrad)" stroke-width="3"/>
+  </g>
+  
+  <text x="200" y="165" font-family="Arial, sans-serif" font-size="30" font-weight="700" fill="white" text-anchor="middle" filter="url(#glow)">Cybersecurity</text>
+  
+  <text x="200" y="190" font-family="Arial, sans-serif" font-size="14" font-weight="500" fill="rgba(255,255,255,0.9)" text-anchor="middle">µLearn</text>
+</svg>

--- a/public/assets/InterestGroups/design.svg
+++ b/public/assets/InterestGroups/design.svg
@@ -1,0 +1,31 @@
+<svg width="400" height="250" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="uiuxGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#667eea;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#764ba2;stop-opacity:1" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <rect width="400" height="250" fill="url(#uiuxGrad)" rx="16"/>
+  
+  <circle cx="80" cy="125" r="120" fill="rgba(255,255,255,0.1)"/>
+  <circle cx="320" cy="200" r="80" fill="rgba(255,255,255,0.08)"/>
+  
+  <g transform="translate(200, 85)">
+    <path d="M-15,-25 L-10,-30 L10,-10 L5,-5 Z" fill="white" filter="url(#glow)"/>
+    <path d="M5,-5 L-5,5 L-10,0 L0,-10 Z" fill="white" opacity="0.8" filter="url(#glow)"/>
+    <circle cx="-12" cy="-28" r="4" fill="white" filter="url(#glow)"/>
+    <rect x="-8" y="8" width="16" height="16" rx="2" fill="white" opacity="0.9" filter="url(#glow)"/>
+  </g>
+  
+  <text x="200" y="165" font-family="Arial, sans-serif" font-size="32" font-weight="700" fill="white" text-anchor="middle" filter="url(#glow)">UI/UX Design</text>
+  
+  <text x="200" y="190" font-family="Arial, sans-serif" font-size="14" font-weight="500" fill="rgba(255,255,255,0.9)" text-anchor="middle">µLearn</text>
+</svg>

--- a/public/assets/InterestGroups/entrepreneurship.svg
+++ b/public/assets/InterestGroups/entrepreneurship.svg
@@ -1,0 +1,29 @@
+<svg width="400" height="250" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="entreGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f59e0b;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#dc2626;stop-opacity:1" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <rect width="400" height="250" fill="url(#entreGrad)" rx="16"/>
+  
+  <circle cx="80" cy="125" r="120" fill="rgba(255,255,255,0.1)"/>
+  <circle cx="320" cy="200" r="80" fill="rgba(255,255,255,0.08)"/>
+  
+  <g transform="translate(200, 95)" filter="url(#glow)">
+    <path d="M0,-25 L-8,-8 L-25,-5 L-12,5 L-15,22 L0,13 L15,22 L12,5 L25,-5 L8,-8 Z" fill="white" opacity="0.9"/>
+    <circle cx="0" cy="0" r="8" fill="url(#entreGrad)"/>
+  </g>
+  
+  <text x="200" y="165" font-family="Arial, sans-serif" font-size="28" font-weight="700" fill="white" text-anchor="middle" filter="url(#glow)">Entrepreneurship</text>
+  
+  <text x="200" y="190" font-family="Arial, sans-serif" font-size="14" font-weight="500" fill="rgba(255,255,255,0.9)" text-anchor="middle">µLearn</text>
+</svg>

--- a/public/assets/InterestGroups/game.svg
+++ b/public/assets/InterestGroups/game.svg
@@ -1,0 +1,33 @@
+<svg width="400" height="250" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gameGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#f59e0b;stop-opacity:1" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <rect width="400" height="250" fill="url(#gameGrad)" rx="16"/>
+  
+  <circle cx="80" cy="125" r="120" fill="rgba(255,255,255,0.1)"/>
+  <circle cx="320" cy="200" r="80" fill="rgba(255,255,255,0.08)"/>
+  
+  <g transform="translate(200, 100)" filter="url(#glow)">
+    <rect x="-35" y="-15" width="70" height="30" rx="15" fill="white"/>
+    <circle cx="-20" cy="0" r="6" fill="url(#gameGrad)"/>
+    <circle cx="20" cy="-5" r="4" fill="url(#gameGrad)"/>
+    <circle cx="27" cy="0" r="4" fill="url(#gameGrad)"/>
+    <rect x="-10" y="-5" width="3" height="10" fill="url(#gameGrad)"/>
+    <rect x="-15" y="0" width="10" height="3" fill="url(#gameGrad)"/>
+  </g>
+  
+  <text x="200" y="165" font-family="Arial, sans-serif" font-size="26" font-weight="700" fill="white" text-anchor="middle" filter="url(#glow)">Game Development</text>
+  
+  <text x="200" y="190" font-family="Arial, sans-serif" font-size="14" font-weight="500" fill="rgba(255,255,255,0.9)" text-anchor="middle">µLearn</text>
+</svg>

--- a/public/assets/InterestGroups/iot.svg
+++ b/public/assets/InterestGroups/iot.svg
@@ -1,0 +1,36 @@
+<svg width="400" height="250" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="iotGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#06b6d4;stop-opacity:1" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <rect width="400" height="250" fill="url(#iotGrad)" rx="16"/>
+  
+  <circle cx="80" cy="125" r="120" fill="rgba(255,255,255,0.1)"/>
+  <circle cx="320" cy="200" r="80" fill="rgba(255,255,255,0.08)"/>
+  
+  <g transform="translate(200, 95)" filter="url(#glow)">
+    <rect x="-18" y="-10" width="36" height="40" rx="4" fill="white"/>
+    <circle cx="-8" cy="5" r="4" fill="url(#iotGrad)"/>
+    <circle cx="8" cy="5" r="4" fill="url(#iotGrad)"/>
+    <rect x="-10" y="15" width="20" height="3" rx="1.5" fill="url(#iotGrad)"/>
+    <circle cx="-25" cy="0" r="3" fill="white"/>
+    <circle cx="25" cy="0" r="3" fill="white"/>
+    <line x1="-22" y1="0" x2="-18" y2="0" stroke="white" stroke-width="2"/>
+    <line x1="22" y1="0" x2="18" y2="0" stroke="white" stroke-width="2"/>
+  </g>
+  
+  <text x="200" y="160" font-family="Arial, sans-serif" font-size="22" font-weight="700" fill="white" text-anchor="middle" filter="url(#glow)">Internet Of Things (IOT)</text>
+  <text x="200" y="182" font-family="Arial, sans-serif" font-size="22" font-weight="700" fill="white" text-anchor="middle" filter="url(#glow)">And Robotics</text>
+  
+  <text x="200" y="205" font-family="Arial, sans-serif" font-size="14" font-weight="500" fill="rgba(255,255,255,0.9)" text-anchor="middle">µLearn</text>
+</svg>

--- a/public/assets/InterestGroups/marketing.svg
+++ b/public/assets/InterestGroups/marketing.svg
@@ -1,0 +1,32 @@
+<svg width="400" height="250" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="marketingGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#db2777;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#7c3aed;stop-opacity:1" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <rect width="400" height="250" fill="url(#marketingGrad)" rx="16"/>
+  
+  <circle cx="80" cy="125" r="120" fill="rgba(255,255,255,0.1)"/>
+  <circle cx="320" cy="200" r="80" fill="rgba(255,255,255,0.08)"/>
+  
+  <g transform="translate(200, 100)" filter="url(#glow)">
+    <path d="M-25,-10 L-25,15 L-15,20 L-5,15 L5,15 L15,20 L25,15 L25,-10 Z" fill="white" opacity="0.9"/>
+    <circle cx="-15" cy="0" r="5" fill="url(#marketingGrad)"/>
+    <circle cx="0" cy="-5" r="5" fill="url(#marketingGrad)"/>
+    <circle cx="15" cy="0" r="5" fill="url(#marketingGrad)"/>
+    <path d="M-15,0 L0,-5 L15,0" stroke="url(#marketingGrad)" stroke-width="2" fill="none"/>
+  </g>
+  
+  <text x="200" y="165" font-family="Arial, sans-serif" font-size="28" font-weight="700" fill="white" text-anchor="middle" filter="url(#glow)">Digital Marketing</text>
+  
+  <text x="200" y="190" font-family="Arial, sans-serif" font-size="14" font-weight="500" fill="rgba(255,255,255,0.9)" text-anchor="middle">µLearn</text>
+</svg>

--- a/public/assets/InterestGroups/product.svg
+++ b/public/assets/InterestGroups/product.svg
@@ -1,0 +1,34 @@
+<svg width="400" height="250" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="productGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#10b981;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#06b6d4;stop-opacity:1" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <rect width="400" height="250" fill="url(#productGrad)" rx="16"/>
+  
+  <circle cx="80" cy="125" r="120" fill="rgba(255,255,255,0.1)"/>
+  <circle cx="320" cy="200" r="80" fill="rgba(255,255,255,0.08)"/>
+  
+  <g transform="translate(200, 95)" filter="url(#glow)">
+    <rect x="-25" y="-15" width="50" height="40" rx="3" fill="white" opacity="0.9"/>
+    <rect x="-20" y="-8" width="15" height="3" fill="url(#productGrad)"/>
+    <rect x="-20" y="-2" width="15" height="3" fill="url(#productGrad)"/>
+    <rect x="-20" y="4" width="15" height="3" fill="url(#productGrad)"/>
+    <rect x="-20" y="10" width="15" height="3" fill="url(#productGrad)"/>
+    <rect x="2" y="-8" width="18" height="26" rx="2" fill="url(#productGrad)" opacity="0.6"/>
+  </g>
+  
+  <text x="200" y="160" font-family="Arial, sans-serif" font-size="26" font-weight="700" fill="white" text-anchor="middle" filter="url(#glow)">Product</text>
+  <text x="200" y="185" font-family="Arial, sans-serif" font-size="26" font-weight="700" fill="white" text-anchor="middle" filter="url(#glow)">Management</text>
+  
+  <text x="200" y="208" font-family="Arial, sans-serif" font-size="14" font-weight="500" fill="rgba(255,255,255,0.9)" text-anchor="middle">µLearn</text>
+</svg>

--- a/public/assets/InterestGroups/webdev.svg
+++ b/public/assets/InterestGroups/webdev.svg
@@ -1,0 +1,30 @@
+<svg width="400" height="250" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="webdevGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#7c3aed;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#4c1d95;stop-opacity:1" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <rect width="400" height="250" fill="url(#webdevGrad)" rx="16"/>
+  
+  <circle cx="80" cy="125" r="120" fill="rgba(255,255,255,0.1)"/>
+  <circle cx="320" cy="200" r="80" fill="rgba(255,255,255,0.08)"/>
+  
+  <g transform="translate(200, 100)" filter="url(#glow)">
+    <path d="M-25,-15 L-35,-5 L-35,5 L-25,15" stroke="white" stroke-width="4" fill="none" stroke-linecap="round"/>
+    <path d="M25,-15 L35,-5 L35,5 L25,15" stroke="white" stroke-width="4" fill="none" stroke-linecap="round"/>
+    <line x1="-10" y1="-20" x2="10" y2="20" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  </g>
+  
+  <text x="200" y="165" font-family="Arial, sans-serif" font-size="28" font-weight="700" fill="white" text-anchor="middle" filter="url(#glow)">Web Development</text>
+  
+  <text x="200" y="190" font-family="Arial, sans-serif" font-size="14" font-weight="500" fill="rgba(255,255,255,0.9)" text-anchor="middle">µLearn</text>
+</svg>

--- a/src/app/interest-groups/page.tsx
+++ b/src/app/interest-groups/page.tsx
@@ -1,39 +1,38 @@
 "use client";
-
+import { cdnUrl } from "@/services/cdn";
 import React, { useState } from "react";
 import { motion, useScroll, useTransform } from "framer-motion";
 import { Search, ArrowRight, Users, Target, BookOpen, Lightbulb, TrendingUp } from "lucide-react";
-import { cdnUrl } from "@/services/cdn";
 import MuImage from "@/components/MuImage";
 import { interestGroups } from "@/data/data";
 
-const bglogo = cdnUrl("/src/modules/Public/InterestGroups/assets/µ.png");
+const bgLogo = cdnUrl("/src/modules/Public/Manifesto/assets/µ.png");
 
 const workflowSteps = [
     {
         icon: Target,
-        title: "Clear Goal",
-        description: "The journey is designed to take a student from initial curiosity to career readiness."
+        title: "Reach Level 4",
+        description: "Start your µLearn journey and progress to Level 4 to unlock Interest Group related tasks and opportunities."
     },
     {
         icon: Users,
-        title: "Simple Onboarding",
-        description: "Members begin by exploring a group and using foundational resources to get started."
+        title: "Choose Your Interest Group",
+        description: "Explore and join an Interest Group that aligns with your passion and career goals from the available domains."
     },
     {
         icon: BookOpen,
-        title: "Community Learning",
-        description: "Growth happens through active participation in meetings and curated learning materials."
+        title: "Learn Through Real-World Problems",
+        description: "Engage in hands-on learning by working on real-world problems and industry-relevant projects within your group."
     },
     {
         icon: Lightbulb,
-        title: "Dual Support System",
-        description: "Get guidance from both student leads (peers) and industry mentors (professionals)."
+        title: "Build Practical Skills",
+        description: "Develop job-ready skills through collaborative learning, mentorship from peers and industry experts, and curated resources."
     },
     {
         icon: TrendingUp,
-        title: "Practical Outcome",
-        description: "Focus on building real-world skills and mapping them directly to job opportunities."
+        title: "Advance Your Career",
+        description: "Apply your skills to meaningful projects, build your portfolio, and prepare for career opportunities in your chosen field."
     }
 ];
 
@@ -71,38 +70,20 @@ export default function InterestGroups() {
             {/* Hero Section */}
             <motion.section 
                 style={{ y: heroY, opacity: heroOpacity }}
-                className="relative overflow-hidden bg-gradient-to-br from-blue-600 via-blue-700 to-indigo-800 pt-20 pb-32 md:pt-32 md:pb-40"
+                className="relative overflow-hidden bg-mulearn-trusty-blue pt-20 pb-32 md:pt-32 md:pb-40"
             >
                 {/* µLearn Background Logo */}
                 <div className="absolute inset-0 overflow-hidden pointer-events-none">
                     <MuImage
-                        src={bglogo}
+                        src={bgLogo}
                         alt="µLearn background logo"
                         width={600}
                         height={600}
-                        className="absolute left-0 top-1/2 -translate-y-1/2 w-[70vw] md:w-[45vw] lg:w-[35vw] opacity-10 object-contain"
+                        className="absolute left-0 top-0 w-[85vw] md:w-[55vw] lg:w-[45vw] opacity-20 object-contain select-none"
                     />
                 </div>
 
-                {/* Animated background elements */}
-                <div className="absolute inset-0 overflow-hidden pointer-events-none">
-                    <motion.div
-                        animate={{ 
-                            scale: [1, 1.2, 1],
-                            rotate: [0, 90, 0]
-                        }}
-                        transition={{ duration: 20, repeat: Infinity, ease: "linear" }}
-                        className="absolute -top-1/2 -right-1/4 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl"
-                    />
-                    <motion.div
-                        animate={{ 
-                            scale: [1.2, 1, 1.2],
-                            rotate: [90, 0, 90]
-                        }}
-                        transition={{ duration: 15, repeat: Infinity, ease: "linear" }}
-                        className="absolute -bottom-1/2 -left-1/4 w-96 h-96 bg-indigo-500/10 rounded-full blur-3xl"
-                    />
-                </div>
+                {/* Background accents removed to match solid brand banner */}
 
                 <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                     <motion.div
@@ -125,7 +106,7 @@ export default function InterestGroups() {
                         <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold text-white mb-6 leading-tight">
                             Find Your Tribe,
                             <br />
-                            <span className="text-blue-200">Grow Together</span>
+                            <span className="text-mulearn-whitish">Grow Together</span>
                         </h1>
                         
                         <p className="text-lg md:text-xl text-blue-100 max-w-3xl mx-auto leading-relaxed">
@@ -324,37 +305,38 @@ export default function InterestGroups() {
                             transition={{ duration: 0.5, delay: index * 0.05 }}
                             className="group block"
                         >
-                            <div className="relative h-full bg-white rounded-2xl shadow-md hover:shadow-2xl transition-all duration-300 overflow-hidden border border-gray-100 p-6">
-                                {/* Card Content */}
-                                <div className="relative z-10 flex flex-col items-center text-center h-full">
+                            <div className="relative h-full bg-white rounded-2xl shadow-md hover:shadow-2xl transition-all duration-300 overflow-hidden border border-gray-100">
+                                {/* Image Header - Full width gradient background with centered image */}
+                                <div className="relative h-48 overflow-hidden rounded-t-2xl">
                                     <MuImage
                                         src={group.image}
                                         alt={group.name}
-                                        width={80}
-                                        height={80}
-                                        className="mb-4 object-contain group-hover:scale-110 transition-transform duration-300"
+                                        width={400}
+                                        height={192}
+                                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
                                     />
+                                </div>
+
+                                {/* Card Content */}
+                                <div className="relative z-10 flex flex-col p-6">
                                     <h3 className="text-xl font-bold text-gray-900 mb-2 group-hover:text-blue-600 transition-colors duration-300">
                                         {group.name}
                                     </h3>
-                                    <p className="text-sm text-gray-600 mb-4">
+                                    <p className="text-sm text-gray-600 mb-4 flex-grow">
                                         {group.tagline}
                                     </p>
                                     
-                                    <div className="mt-auto flex items-center gap-2 text-blue-600 font-medium text-sm group-hover:gap-3 transition-all duration-300">
+                                    <div className="flex items-center gap-2 text-blue-600 font-medium text-sm group-hover:gap-3 transition-all duration-300">
                                         Explore <ArrowRight className="w-4 h-4" />
                                     </div>
                                 </div>
 
                                 {/* Hover Overlay */}
-                                <div className="absolute inset-0 bg-gradient-to-br from-blue-600 to-indigo-700 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center p-6 z-20">
-                                    <p className="text-white text-sm leading-relaxed">
+                                <div className="absolute inset-0 bg-gradient-to-br from-blue-600 to-indigo-700 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center p-6 z-20 rounded-2xl">
+                                    <p className="text-white text-sm leading-relaxed text-center">
                                         {group.description}
                                     </p>
                                 </div>
-
-                                {/* Decorative gradient on hover */}
-                                <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 to-indigo-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                             </div>
                         </motion.a>
                     ))}
@@ -372,7 +354,7 @@ export default function InterestGroups() {
             </section>
 
             {/* Call to Action */}
-            <section className="py-16 md:py-24 px-4 sm:px-6 lg:px-8 bg-gradient-to-br from-blue-600 via-blue-700 to-indigo-800">
+            <section className="py-16 md:py-24 px-4 sm:px-6 lg:px-8 bg-mulearn-trusty-blue">
                 <motion.div
                     initial={{ opacity: 0, y: 30 }}
                     whileInView={{ opacity: 1, y: 0 }}
@@ -383,17 +365,20 @@ export default function InterestGroups() {
                     <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
                         Ready to Start Your Journey?
                     </h2>
-                    <p className="text-lg text-blue-100 mb-8 max-w-2xl mx-auto">
+                    <p className="text-lg text-mulearn-whitish/90 mb-8 max-w-2xl mx-auto">
                         Join thousands of learners who are building skills, making connections, 
                         and preparing for the careers of tomorrow.
                     </p>
-                    <motion.button
+                    <motion.a
+                        href="https://app.mulearn.org/dashboard/profile"
+                        target="_blank"
+                        rel="noopener noreferrer"
                         whileHover={{ scale: 1.05 }}
                         whileTap={{ scale: 0.95 }}
-                        className="inline-flex items-center gap-2 px-8 py-4 bg-white text-blue-700 rounded-full font-semibold text-lg shadow-xl hover:shadow-2xl transition-all duration-300"
+                        className="inline-flex items-center gap-2 px-8 py-4 bg-white text-mulearn-trusty-blue rounded-full font-semibold text-lg shadow-xl hover:shadow-2xl hover:bg-mulearn-duke-purple hover:text-mulearn-whitish transition-all duration-300"
                     >
                         Join an Interest Group <ArrowRight className="w-5 h-5" />
-                    </motion.button>
+                    </motion.a>
                 </motion.div>
             </section>
         </div>

--- a/src/app/interest-groups/page.tsx
+++ b/src/app/interest-groups/page.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+import React, { useState } from "react";
+import { motion, useScroll, useTransform } from "framer-motion";
+import { Search, ArrowRight, Users, Target, BookOpen, Lightbulb, TrendingUp } from "lucide-react";
+import { cdnUrl } from "@/services/cdn";
+import MuImage from "@/components/MuImage";
+import { interestGroups } from "@/data/data";
+
+const bglogo = cdnUrl("/src/modules/Public/InterestGroups/assets/µ.png");
+
+const workflowSteps = [
+    {
+        icon: Target,
+        title: "Clear Goal",
+        description: "The journey is designed to take a student from initial curiosity to career readiness."
+    },
+    {
+        icon: Users,
+        title: "Simple Onboarding",
+        description: "Members begin by exploring a group and using foundational resources to get started."
+    },
+    {
+        icon: BookOpen,
+        title: "Community Learning",
+        description: "Growth happens through active participation in meetings and curated learning materials."
+    },
+    {
+        icon: Lightbulb,
+        title: "Dual Support System",
+        description: "Get guidance from both student leads (peers) and industry mentors (professionals)."
+    },
+    {
+        icon: TrendingUp,
+        title: "Practical Outcome",
+        description: "Focus on building real-world skills and mapping them directly to job opportunities."
+    }
+];
+
+const coreValues = [
+    {
+        title: "Collaboration",
+        description: "Learn together, grow together",
+        icon: "🤝"
+    },
+    {
+        title: "Curiosity",
+        description: "Question everything, explore endlessly",
+        icon: "🔍"
+    },
+    {
+        title: "Community",
+        description: "Build connections that last",
+        icon: "💙"
+    }
+];
+
+export default function InterestGroups() {
+    const [searchTerm, setSearchTerm] = useState("");
+    const { scrollY } = useScroll();
+    const heroY = useTransform(scrollY, [0, 500], [0, 150]);
+    const heroOpacity = useTransform(scrollY, [0, 300], [1, 0]);
+
+    const filteredGroups = interestGroups.filter(group =>
+        group.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        group.tagline.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
+    return (
+        <div className="bg-gradient-to-b from-slate-50 to-white min-h-screen">
+            {/* Hero Section */}
+            <motion.section 
+                style={{ y: heroY, opacity: heroOpacity }}
+                className="relative overflow-hidden bg-gradient-to-br from-blue-600 via-blue-700 to-indigo-800 pt-20 pb-32 md:pt-32 md:pb-40"
+            >
+                {/* µLearn Background Logo */}
+                <div className="absolute inset-0 overflow-hidden pointer-events-none">
+                    <MuImage
+                        src={bglogo}
+                        alt="µLearn background logo"
+                        width={600}
+                        height={600}
+                        className="absolute left-0 top-1/2 -translate-y-1/2 w-[70vw] md:w-[45vw] lg:w-[35vw] opacity-10 object-contain"
+                    />
+                </div>
+
+                {/* Animated background elements */}
+                <div className="absolute inset-0 overflow-hidden pointer-events-none">
+                    <motion.div
+                        animate={{ 
+                            scale: [1, 1.2, 1],
+                            rotate: [0, 90, 0]
+                        }}
+                        transition={{ duration: 20, repeat: Infinity, ease: "linear" }}
+                        className="absolute -top-1/2 -right-1/4 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl"
+                    />
+                    <motion.div
+                        animate={{ 
+                            scale: [1.2, 1, 1.2],
+                            rotate: [90, 0, 90]
+                        }}
+                        transition={{ duration: 15, repeat: Infinity, ease: "linear" }}
+                        className="absolute -bottom-1/2 -left-1/4 w-96 h-96 bg-indigo-500/10 rounded-full blur-3xl"
+                    />
+                </div>
+
+                <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                    <motion.div
+                        initial={{ opacity: 0, y: 30 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ duration: 0.8 }}
+                        className="text-center"
+                    >
+                        <motion.div 
+                            initial={{ scale: 0.9, opacity: 0 }}
+                            animate={{ scale: 1, opacity: 1 }}
+                            transition={{ duration: 0.5 }}
+                            className="inline-block mb-6 px-6 py-2 bg-white/20 backdrop-blur-sm rounded-full border border-white/30"
+                        >
+                            <span className="text-white text-sm font-medium tracking-wide uppercase">
+                                Interest Groups
+                            </span>
+                        </motion.div>
+                        
+                        <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold text-white mb-6 leading-tight">
+                            Find Your Tribe,
+                            <br />
+                            <span className="text-blue-200">Grow Together</span>
+                        </h1>
+                        
+                        <p className="text-lg md:text-xl text-blue-100 max-w-3xl mx-auto leading-relaxed">
+                            Join communities where learners explore specific domains, collaborate on projects, 
+                            and grow together through shared curiosity and hands-on learning.
+                        </p>
+                    </motion.div>
+                </div>
+
+                {/* Decorative wave */}
+                <div className="absolute bottom-0 left-0 right-0">
+                    <svg viewBox="0 0 1440 120" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-auto">
+                        <path d="M0,64L80,69.3C160,75,320,85,480,80C640,75,800,53,960,48C1120,43,1280,53,1360,58.7L1440,64L1440,120L1360,120C1280,120,1120,120,960,120C800,120,640,120,480,120C320,120,160,120,80,120L0,120Z" fill="rgb(248, 250, 252)"/>
+                    </svg>
+                </div>
+            </motion.section>
+
+            {/* Core Values Section */}
+            <section className="py-16 md:py-24 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto">
+                <motion.div
+                    initial={{ opacity: 0, y: 30 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ duration: 0.8 }}
+                    className="text-center mb-16"
+                >
+                    <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+                        Built on Community Values
+                    </h2>
+                    <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+                        At µLearn, we believe in the power of learning together
+                    </p>
+                </motion.div>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+                    {coreValues.map((value, index) => (
+                        <motion.div
+                            key={value.title}
+                            initial={{ opacity: 0, y: 30 }}
+                            whileInView={{ opacity: 1, y: 0 }}
+                            viewport={{ once: true }}
+                            transition={{ duration: 0.6, delay: index * 0.2 }}
+                            className="text-center p-8 rounded-2xl bg-white shadow-sm hover:shadow-xl transition-all duration-300 border border-gray-100"
+                        >
+                            <div className="text-5xl mb-4">{value.icon}</div>
+                            <h3 className="text-xl font-bold text-gray-900 mb-2">{value.title}</h3>
+                            <p className="text-gray-600">{value.description}</p>
+                        </motion.div>
+                    ))}
+                </div>
+            </section>
+
+            {/* How It Works Timeline */}
+            <section className="py-16 md:py-24 px-4 sm:px-6 lg:px-8 bg-gradient-to-b from-blue-50 to-white">
+                <div className="max-w-6xl mx-auto">
+                    <motion.div
+                        initial={{ opacity: 0, y: 30 }}
+                        whileInView={{ opacity: 1, y: 0 }}
+                        viewport={{ once: true }}
+                        transition={{ duration: 0.8 }}
+                        className="text-center mb-16"
+                    >
+                        <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+                            Your Learning Journey
+                        </h2>
+                        <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+                            From curiosity to career readiness in five simple steps
+                        </p>
+                    </motion.div>
+
+                    {/* Desktop Timeline */}
+                    <div className="hidden md:block relative">
+                        <div className="absolute left-1/2 top-0 bottom-0 w-0.5 bg-gradient-to-b from-blue-200 via-blue-400 to-blue-600 transform -translate-x-1/2" />
+                        
+                        {workflowSteps.map((step, index) => {
+                            const Icon = step.icon;
+                            const isLeft = index % 2 === 0;
+                            
+                            return (
+                                <motion.div
+                                    key={step.title}
+                                    initial={{ opacity: 0, x: isLeft ? -50 : 50 }}
+                                    whileInView={{ opacity: 1, x: 0 }}
+                                    viewport={{ once: true, amount: 0.5 }}
+                                    transition={{ duration: 0.6, delay: index * 0.1 }}
+                                    className="relative mb-24 last:mb-0"
+                                >
+                                    <div className={`flex items-center ${isLeft ? 'justify-end' : 'justify-start'}`}>
+                                        <div className={`w-5/12 ${isLeft ? 'pr-12 text-right' : 'pl-12 text-left'}`}>
+                                            <div className="bg-white p-6 rounded-2xl shadow-lg border border-gray-100 hover:shadow-xl transition-shadow duration-300">
+                                                <div className={`flex items-center gap-3 mb-3 ${isLeft ? 'justify-end' : 'justify-start'}`}>
+                                                    <Icon className="w-6 h-6 text-blue-600" />
+                                                    <h3 className="text-xl font-bold text-gray-900">{step.title}</h3>
+                                                </div>
+                                                <p className="text-gray-600 leading-relaxed">{step.description}</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+                                    {/* Center dot */}
+                                    <div className="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2">
+                                        <motion.div
+                                            initial={{ scale: 0 }}
+                                            whileInView={{ scale: 1 }}
+                                            viewport={{ once: true }}
+                                            transition={{ duration: 0.4, delay: index * 0.1 + 0.2 }}
+                                            className="w-12 h-12 bg-blue-600 rounded-full flex items-center justify-center shadow-lg"
+                                        >
+                                            <div className="w-6 h-6 bg-white rounded-full" />
+                                        </motion.div>
+                                    </div>
+                                </motion.div>
+                            );
+                        })}
+                    </div>
+
+                    {/* Mobile Timeline */}
+                    <div className="md:hidden space-y-8">
+                        {workflowSteps.map((step, index) => {
+                            const Icon = step.icon;
+                            
+                            return (
+                                <motion.div
+                                    key={step.title}
+                                    initial={{ opacity: 0, y: 30 }}
+                                    whileInView={{ opacity: 1, y: 0 }}
+                                    viewport={{ once: true }}
+                                    transition={{ duration: 0.6, delay: index * 0.1 }}
+                                    className="relative pl-12"
+                                >
+                                    {/* Vertical line */}
+                                    {index < workflowSteps.length - 1 && (
+                                        <div className="absolute left-5 top-12 bottom-0 w-0.5 bg-blue-200 transform -translate-x-1/2" />
+                                    )}
+                                    
+                                    {/* Dot */}
+                                    <div className="absolute left-0 top-0">
+                                        <div className="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center shadow-md">
+                                            <Icon className="w-5 h-5 text-white" />
+                                        </div>
+                                    </div>
+                                    
+                                    {/* Content */}
+                                    <div className="bg-white p-6 rounded-xl shadow-md border border-gray-100">
+                                        <h3 className="text-lg font-bold text-gray-900 mb-2">{step.title}</h3>
+                                        <p className="text-gray-600 text-sm leading-relaxed">{step.description}</p>
+                                    </div>
+                                </motion.div>
+                            );
+                        })}
+                    </div>
+                </div>
+            </section>
+
+            {/* Interest Groups Section */}
+            <section className="py-16 md:py-24 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto">
+                <motion.div
+                    initial={{ opacity: 0, y: 30 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ duration: 0.8 }}
+                    className="text-center mb-12"
+                >
+                    <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+                        Explore Interest Groups
+                    </h2>
+                    <p className="text-lg text-gray-600 max-w-2xl mx-auto mb-8">
+                        Choose a domain that excites you and start your learning journey today
+                    </p>
+
+                    {/* Search Bar */}
+                    <div className="max-w-md mx-auto relative">
+                        <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
+                        <input
+                            type="text"
+                            placeholder="Search interest groups..."
+                            value={searchTerm}
+                            onChange={(e) => setSearchTerm(e.target.value)}
+                            className="w-full pl-12 pr-4 py-3 rounded-full border-2 border-gray-200 focus:border-blue-500 focus:outline-none transition-colors duration-300 text-gray-900 placeholder-gray-400"
+                            aria-label="Search interest groups"
+                        />
+                    </div>
+                </motion.div>
+
+                {/* Groups Grid */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                    {filteredGroups.map((group, index) => (
+                        <motion.a
+                            key={group.name}
+                            href={group.link}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            initial={{ opacity: 0, y: 30 }}
+                            whileInView={{ opacity: 1, y: 0 }}
+                            viewport={{ once: true }}
+                            transition={{ duration: 0.5, delay: index * 0.05 }}
+                            className="group block"
+                        >
+                            <div className="relative h-full bg-white rounded-2xl shadow-md hover:shadow-2xl transition-all duration-300 overflow-hidden border border-gray-100 p-6">
+                                {/* Card Content */}
+                                <div className="relative z-10 flex flex-col items-center text-center h-full">
+                                    <MuImage
+                                        src={group.image}
+                                        alt={group.name}
+                                        width={80}
+                                        height={80}
+                                        className="mb-4 object-contain group-hover:scale-110 transition-transform duration-300"
+                                    />
+                                    <h3 className="text-xl font-bold text-gray-900 mb-2 group-hover:text-blue-600 transition-colors duration-300">
+                                        {group.name}
+                                    </h3>
+                                    <p className="text-sm text-gray-600 mb-4">
+                                        {group.tagline}
+                                    </p>
+                                    
+                                    <div className="mt-auto flex items-center gap-2 text-blue-600 font-medium text-sm group-hover:gap-3 transition-all duration-300">
+                                        Explore <ArrowRight className="w-4 h-4" />
+                                    </div>
+                                </div>
+
+                                {/* Hover Overlay */}
+                                <div className="absolute inset-0 bg-gradient-to-br from-blue-600 to-indigo-700 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center p-6 z-20">
+                                    <p className="text-white text-sm leading-relaxed">
+                                        {group.description}
+                                    </p>
+                                </div>
+
+                                {/* Decorative gradient on hover */}
+                                <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 to-indigo-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+                            </div>
+                        </motion.a>
+                    ))}
+                </div>
+
+                {filteredGroups.length === 0 && (
+                    <motion.div
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        className="text-center py-16"
+                    >
+                        <p className="text-gray-500 text-lg">No interest groups found matching your search.</p>
+                    </motion.div>
+                )}
+            </section>
+
+            {/* Call to Action */}
+            <section className="py-16 md:py-24 px-4 sm:px-6 lg:px-8 bg-gradient-to-br from-blue-600 via-blue-700 to-indigo-800">
+                <motion.div
+                    initial={{ opacity: 0, y: 30 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ duration: 0.8 }}
+                    className="max-w-4xl mx-auto text-center"
+                >
+                    <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
+                        Ready to Start Your Journey?
+                    </h2>
+                    <p className="text-lg text-blue-100 mb-8 max-w-2xl mx-auto">
+                        Join thousands of learners who are building skills, making connections, 
+                        and preparing for the careers of tomorrow.
+                    </p>
+                    <motion.button
+                        whileHover={{ scale: 1.05 }}
+                        whileTap={{ scale: 0.95 }}
+                        className="inline-flex items-center gap-2 px-8 py-4 bg-white text-blue-700 rounded-full font-semibold text-lg shadow-xl hover:shadow-2xl transition-all duration-300"
+                    >
+                        Join an Interest Group <ArrowRight className="w-5 h-5" />
+                    </motion.button>
+                </motion.div>
+            </section>
+        </div>
+    );
+}

--- a/src/app/interest-groups/page.tsx
+++ b/src/app/interest-groups/page.tsx
@@ -166,7 +166,7 @@ export default function InterestGroups() {
                     {/* Desktop Timeline */}
                     <div className="hidden md:block relative">
                         {/* Vertical center line */}
-                        <div className="absolute left-1/2 top-0 bottom-0 w-0.5 bg-mulearn-trusty-blue/30 transform -translate-x-1/2 z-0" />
+                        <div className="absolute left-1/2 transform -translate-x-1/2 w-1 bg-mulearn-trusty-blue/40 rounded-full" style={{ top: 0, height: 'calc(100% - 96px)' }} />
                         
                         {workflowSteps.map((step, index) => {
                             const Icon = step.icon;

--- a/src/app/interest-groups/page.tsx
+++ b/src/app/interest-groups/page.tsx
@@ -65,16 +65,12 @@ export default function InterestGroups() {
     );
 
     return (
-            <div className="bg-gradient-to-b from-mulearn-greyish/10 to-mulearn-whitish min-h-screen">
+        <div className="bg-gradient-to-b from-mulearn-greyish/10 to-mulearn-whitish min-h-screen">
             {/* Hero Section */}
             <motion.section 
                 style={{ y: heroY, opacity: heroOpacity }}
                 className="relative overflow-hidden bg-mulearn-trusty-blue pt-20 pb-32 md:pt-32 md:pb-40"
             >
-                {/* Background logo removed as requested */}
-
-                {/* Background accents removed to match solid brand banner */}
-
                 <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                     <motion.div
                         initial={{ opacity: 0, y: 30 }}
@@ -93,13 +89,13 @@ export default function InterestGroups() {
                             </span>
                         </motion.div>
                         
-                        <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold text-mulearn-whitish mb-6 leading-tight">
+                        <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold text-mulearn-whitish mb-6 leading-tight font-display">
                             Find Your Tribe,
                             <br />
                             <span className="text-mulearn-whitish">Grow Together</span>
                         </h1>
                         
-                            <p className="text-lg md:text-xl text-mulearn-whitish/80 max-w-3xl mx-auto leading-relaxed">
+                        <p className="text-lg md:text-xl text-mulearn-whitish/80 max-w-3xl mx-auto leading-relaxed">
                             Join communities where learners explore specific domains, collaborate on projects, 
                             and grow together through shared curiosity and hands-on learning.
                         </p>
@@ -108,8 +104,8 @@ export default function InterestGroups() {
 
                 {/* Decorative wave */}
                 <div className="absolute bottom-0 left-0 right-0">
-            <svg viewBox="0 0 1440 120" xmlns="http://www.w3.org/2000/svg" className="w-full h-auto">
-                <path d="M0,64L80,69.3C160,75,320,85,480,80C640,75,800,53,960,48C1120,43,1280,53,1360,58.7L1440,64L1440,120L1360,120C1280,120,1120,120,960,120C800,120,640,120,480,120C320,120,160,120,80,120L0,120Z" className="fill-current text-mulearn-whitish/95"/>
+                    <svg viewBox="0 0 1440 120" xmlns="http://www.w3.org/2000/svg" className="w-full h-auto">
+                        <path d="M0,64L80,69.3C160,75,320,85,480,80C640,75,800,53,960,48C1120,43,1280,53,1360,58.7L1440,64L1440,120L1360,120C1280,120,1120,120,960,120C800,120,640,120,480,120C320,120,160,120,80,120L0,120Z" className="fill-current text-mulearn-whitish/95"/>
                     </svg>
                 </div>
             </motion.section>
@@ -123,10 +119,10 @@ export default function InterestGroups() {
                     transition={{ duration: 0.8 }}
                     className="text-center mb-16"
                 >
-                    <h2 className="text-3xl md:text-4xl font-bold text-mulearn-blackish mb-4">
+                    <h2 className="text-3xl md:text-4xl font-bold text-mulearn-blackish mb-4 font-display">
                         Built on Community Values
                     </h2>
-                    <p className="text-lg text-mulearn-gray-600 max-w-2xl mx-auto">
+                    <p className="text-lg text-gray-600 max-w-2xl mx-auto">
                         At µLearn, we believe in the power of learning together
                     </p>
                 </motion.div>
@@ -139,11 +135,11 @@ export default function InterestGroups() {
                             whileInView={{ opacity: 1, y: 0 }}
                             viewport={{ once: true }}
                             transition={{ duration: 0.6, delay: index * 0.2 }}
-                                className="text-center p-8 rounded-2xl bg-mulearn-whitish shadow-sm hover:shadow-xl transition-all duration-300 border border-mulearn-greyish/20"
+                            className="text-center p-8 rounded-2xl bg-mulearn-whitish shadow-sm hover:shadow-xl transition-all duration-300 border border-mulearn-greyish/20"
                         >
                             <div className="text-5xl mb-4">{value.icon}</div>
-                                <h3 className="text-xl font-bold text-mulearn-blackish mb-2">{value.title}</h3>
-                                <p className="text-mulearn-gray-600">{value.description}</p>
+                            <h3 className="text-xl font-bold text-mulearn-blackish mb-2 font-display">{value.title}</h3>
+                            <p className="text-gray-600">{value.description}</p>
                         </motion.div>
                     ))}
                 </div>
@@ -159,16 +155,19 @@ export default function InterestGroups() {
                         transition={{ duration: 0.8 }}
                         className="text-center mb-16"
                     >
-                        <h2 className="text-3xl md:text-4xl font-bold text-mulearn-blackish mb-4">
+                        <h2 className="text-3xl md:text-4xl font-bold text-mulearn-blackish mb-4 font-display">
                             Your Learning Journey
                         </h2>
-                        <p className="text-lg text-mulearn-gray-600 max-w-2xl mx-auto">
+                        <p className="text-lg text-gray-600 max-w-2xl mx-auto">
                             From curiosity to career readiness in five simple steps
                         </p>
                     </motion.div>
 
                     {/* Desktop Timeline */}
                     <div className="hidden md:block relative">
+                        {/* Vertical center line */}
+                        <div className="absolute left-1/2 top-0 bottom-0 w-0.5 bg-mulearn-trusty-blue/30 transform -translate-x-1/2" />
+                        
                         {workflowSteps.map((step, index) => {
                             const Icon = step.icon;
                             const isLeft = index % 2 === 0;
@@ -187,9 +186,9 @@ export default function InterestGroups() {
                                             <div className="bg-mulearn-whitish p-6 rounded-2xl shadow-lg border border-mulearn-greyish/20 hover:shadow-xl transition-shadow duration-300">
                                                 <div className={`flex items-center gap-3 mb-3 ${isLeft ? 'justify-end' : 'justify-start'}`}>
                                                     <Icon className="w-6 h-6 text-mulearn-trusty-blue" />
-                                                    <h3 className="text-xl font-bold text-mulearn-blackish">{step.title}</h3>
+                                                    <h3 className="text-xl font-bold text-mulearn-blackish font-display">{step.title}</h3>
                                                 </div>
-                                                <p className="text-mulearn-gray-600 leading-relaxed">{step.description}</p>
+                                                <p className="text-gray-600 leading-relaxed">{step.description}</p>
                                             </div>
                                         </div>
                                     </div>
@@ -239,8 +238,8 @@ export default function InterestGroups() {
                                     
                                     {/* Content */}
                                     <div className="bg-mulearn-whitish p-6 rounded-xl shadow-md border border-mulearn-greyish/20">
-                                        <h3 className="text-lg font-bold text-mulearn-blackish mb-2">{step.title}</h3>
-                                        <p className="text-mulearn-gray-600 text-sm leading-relaxed">{step.description}</p>
+                                        <h3 className="text-lg font-bold text-mulearn-blackish mb-2 font-display">{step.title}</h3>
+                                        <p className="text-gray-600 text-sm leading-relaxed">{step.description}</p>
                                     </div>
                                 </motion.div>
                             );
@@ -258,22 +257,22 @@ export default function InterestGroups() {
                     transition={{ duration: 0.8 }}
                     className="text-center mb-12"
                 >
-                    <h2 className="text-3xl md:text-4xl font-bold text-mulearn-blackish mb-4">
+                    <h2 className="text-3xl md:text-4xl font-bold text-mulearn-blackish mb-4 font-display">
                         Explore Interest Groups
                     </h2>
-                    <p className="text-lg text-mulearn-gray-600 max-w-2xl mx-auto mb-8">
+                    <p className="text-lg text-gray-600 max-w-2xl mx-auto mb-8">
                         Choose a domain that excites you and start your learning journey today
                     </p>
 
                     {/* Search Bar */}
                     <div className="max-w-md mx-auto relative">
-                        <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-mulearn-gray-600 w-5 h-5" />
+                        <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
                         <input
                             type="text"
                             placeholder="Search interest groups..."
                             value={searchTerm}
                             onChange={(e) => setSearchTerm(e.target.value)}
-                            className="w-full pl-12 pr-4 py-3 rounded-full border-2 border-mulearn-greyish/40 focus:border-mulearn-trusty-blue focus:outline-none transition-colors duration-300 text-mulearn-blackish placeholder-mulearn-gray-600/70"
+                            className="w-full pl-12 pr-4 py-3 rounded-full border-2 border-mulearn-greyish/40 focus:border-mulearn-trusty-blue focus:outline-none transition-colors duration-300 text-mulearn-blackish placeholder-gray-400"
                             aria-label="Search interest groups"
                         />
                     </div>
@@ -294,7 +293,7 @@ export default function InterestGroups() {
                             className="group block"
                         >
                             <div className="relative h-full bg-mulearn-whitish rounded-2xl shadow-md hover:shadow-2xl transition-all duration-300 overflow-hidden border border-mulearn-greyish/20">
-                                {/* Image Header - Full width gradient background with centered image */}
+                                {/* Image Header */}
                                 <div className="relative h-48 overflow-hidden rounded-t-2xl">
                                     <MuImage
                                         src={group.image}
@@ -307,10 +306,10 @@ export default function InterestGroups() {
 
                                 {/* Card Content */}
                                 <div className="relative z-10 flex flex-col p-6">
-                                    <h3 className="text-xl font-bold text-mulearn-blackish mb-2 group-hover:text-mulearn-trusty-blue transition-colors duration-300">
+                                    <h3 className="text-xl font-bold text-mulearn-blackish mb-2 group-hover:text-mulearn-trusty-blue transition-colors duration-300 font-display">
                                         {group.name}
                                     </h3>
-                                    <p className="text-sm text-mulearn-gray-600 mb-4 flex-grow">
+                                    <p className="text-sm text-gray-600 mb-4 flex-grow">
                                         {group.tagline}
                                     </p>
                                     
@@ -336,7 +335,7 @@ export default function InterestGroups() {
                         animate={{ opacity: 1 }}
                         className="text-center py-16"
                     >
-                        <p className="text-mulearn-gray-600 text-lg">No interest groups found matching your search.</p>
+                        <p className="text-gray-500 text-lg">No interest groups found matching your search.</p>
                     </motion.div>
                 )}
             </section>
@@ -350,7 +349,7 @@ export default function InterestGroups() {
                     transition={{ duration: 0.8 }}
                     className="max-w-4xl mx-auto text-center"
                 >
-                    <h2 className="text-3xl md:text-4xl font-bold text-mulearn-whitish mb-6">
+                    <h2 className="text-3xl md:text-4xl font-bold text-mulearn-whitish mb-6 font-display">
                         Ready to Start Your Journey?
                     </h2>
                     <p className="text-lg text-mulearn-whitish/90 mb-8 max-w-2xl mx-auto">

--- a/src/app/interest-groups/page.tsx
+++ b/src/app/interest-groups/page.tsx
@@ -166,7 +166,7 @@ export default function InterestGroups() {
                     {/* Desktop Timeline */}
                     <div className="hidden md:block relative">
                         {/* Vertical center line */}
-                        <div className="absolute left-1/2 top-0 bottom-0 w-0.5 bg-mulearn-trusty-blue/30 transform -translate-x-1/2" />
+                        <div className="absolute left-1/2 top-0 bottom-0 w-0.5 bg-mulearn-trusty-blue/30 transform -translate-x-1/2 z-0" />
                         
                         {workflowSteps.map((step, index) => {
                             const Icon = step.icon;
@@ -179,7 +179,7 @@ export default function InterestGroups() {
                                     whileInView={{ opacity: 1, x: 0 }}
                                     viewport={{ once: true, amount: 0.5 }}
                                     transition={{ duration: 0.6, delay: index * 0.1 }}
-                                    className="relative mb-24 last:mb-0"
+                                    className="relative mb-24 last:mb-0 z-10"
                                 >
                                     <div className={`flex items-center ${isLeft ? 'justify-end' : 'justify-start'}`}>
                                         <div className={`w-5/12 ${isLeft ? 'pr-12 text-right' : 'pl-12 text-left'}`}>
@@ -194,7 +194,7 @@ export default function InterestGroups() {
                                     </div>
                                     
                                     {/* Center dot */}
-                                    <div className="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2">
+                                    <div className="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 z-20">
                                         <motion.div
                                             initial={{ scale: 0 }}
                                             whileInView={{ scale: 1 }}

--- a/src/app/interest-groups/page.tsx
+++ b/src/app/interest-groups/page.tsx
@@ -1,12 +1,11 @@
 "use client";
-import { cdnUrl } from "@/services/cdn";
+// Removed cdnUrl usage
 import React, { useState } from "react";
 import { motion, useScroll, useTransform } from "framer-motion";
 import { Search, ArrowRight, Users, Target, BookOpen, Lightbulb, TrendingUp } from "lucide-react";
 import MuImage from "@/components/MuImage";
 import { interestGroups } from "@/data/data";
 
-const bgLogo = cdnUrl("/src/modules/Public/Manifesto/assets/µ.png");
 
 const workflowSteps = [
     {
@@ -66,22 +65,13 @@ export default function InterestGroups() {
     );
 
     return (
-        <div className="bg-gradient-to-b from-slate-50 to-white min-h-screen">
+            <div className="bg-gradient-to-b from-mulearn-greyish/10 to-mulearn-whitish min-h-screen">
             {/* Hero Section */}
             <motion.section 
                 style={{ y: heroY, opacity: heroOpacity }}
                 className="relative overflow-hidden bg-mulearn-trusty-blue pt-20 pb-32 md:pt-32 md:pb-40"
             >
-                {/* µLearn Background Logo */}
-                <div className="absolute inset-0 overflow-hidden pointer-events-none">
-                    <MuImage
-                        src={bgLogo}
-                        alt="µLearn background logo"
-                        width={600}
-                        height={600}
-                        className="absolute left-0 top-0 w-[85vw] md:w-[55vw] lg:w-[45vw] opacity-20 object-contain select-none"
-                    />
-                </div>
+                {/* Background logo removed as requested */}
 
                 {/* Background accents removed to match solid brand banner */}
 
@@ -98,18 +88,18 @@ export default function InterestGroups() {
                             transition={{ duration: 0.5 }}
                             className="inline-block mb-6 px-6 py-2 bg-white/20 backdrop-blur-sm rounded-full border border-white/30"
                         >
-                            <span className="text-white text-sm font-medium tracking-wide uppercase">
+                            <span className="text-mulearn-whitish text-sm font-medium tracking-wide uppercase">
                                 Interest Groups
                             </span>
                         </motion.div>
                         
-                        <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold text-white mb-6 leading-tight">
+                        <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold text-mulearn-whitish mb-6 leading-tight">
                             Find Your Tribe,
                             <br />
                             <span className="text-mulearn-whitish">Grow Together</span>
                         </h1>
                         
-                        <p className="text-lg md:text-xl text-blue-100 max-w-3xl mx-auto leading-relaxed">
+                            <p className="text-lg md:text-xl text-mulearn-whitish/80 max-w-3xl mx-auto leading-relaxed">
                             Join communities where learners explore specific domains, collaborate on projects, 
                             and grow together through shared curiosity and hands-on learning.
                         </p>
@@ -118,8 +108,8 @@ export default function InterestGroups() {
 
                 {/* Decorative wave */}
                 <div className="absolute bottom-0 left-0 right-0">
-                    <svg viewBox="0 0 1440 120" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-auto">
-                        <path d="M0,64L80,69.3C160,75,320,85,480,80C640,75,800,53,960,48C1120,43,1280,53,1360,58.7L1440,64L1440,120L1360,120C1280,120,1120,120,960,120C800,120,640,120,480,120C320,120,160,120,80,120L0,120Z" fill="rgb(248, 250, 252)"/>
+            <svg viewBox="0 0 1440 120" xmlns="http://www.w3.org/2000/svg" className="w-full h-auto">
+                <path d="M0,64L80,69.3C160,75,320,85,480,80C640,75,800,53,960,48C1120,43,1280,53,1360,58.7L1440,64L1440,120L1360,120C1280,120,1120,120,960,120C800,120,640,120,480,120C320,120,160,120,80,120L0,120Z" className="fill-current text-mulearn-whitish/95"/>
                     </svg>
                 </div>
             </motion.section>
@@ -133,10 +123,10 @@ export default function InterestGroups() {
                     transition={{ duration: 0.8 }}
                     className="text-center mb-16"
                 >
-                    <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+                    <h2 className="text-3xl md:text-4xl font-bold text-mulearn-blackish mb-4">
                         Built on Community Values
                     </h2>
-                    <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+                    <p className="text-lg text-mulearn-gray-600 max-w-2xl mx-auto">
                         At µLearn, we believe in the power of learning together
                     </p>
                 </motion.div>
@@ -149,18 +139,18 @@ export default function InterestGroups() {
                             whileInView={{ opacity: 1, y: 0 }}
                             viewport={{ once: true }}
                             transition={{ duration: 0.6, delay: index * 0.2 }}
-                            className="text-center p-8 rounded-2xl bg-white shadow-sm hover:shadow-xl transition-all duration-300 border border-gray-100"
+                                className="text-center p-8 rounded-2xl bg-mulearn-whitish shadow-sm hover:shadow-xl transition-all duration-300 border border-mulearn-greyish/20"
                         >
                             <div className="text-5xl mb-4">{value.icon}</div>
-                            <h3 className="text-xl font-bold text-gray-900 mb-2">{value.title}</h3>
-                            <p className="text-gray-600">{value.description}</p>
+                                <h3 className="text-xl font-bold text-mulearn-blackish mb-2">{value.title}</h3>
+                                <p className="text-mulearn-gray-600">{value.description}</p>
                         </motion.div>
                     ))}
                 </div>
             </section>
 
             {/* How It Works Timeline */}
-            <section className="py-16 md:py-24 px-4 sm:px-6 lg:px-8 bg-gradient-to-b from-blue-50 to-white">
+            <section className="py-16 md:py-24 px-4 sm:px-6 lg:px-8 bg-gradient-to-b from-mulearn-greyish/10 to-mulearn-whitish">
                 <div className="max-w-6xl mx-auto">
                     <motion.div
                         initial={{ opacity: 0, y: 30 }}
@@ -169,18 +159,16 @@ export default function InterestGroups() {
                         transition={{ duration: 0.8 }}
                         className="text-center mb-16"
                     >
-                        <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+                        <h2 className="text-3xl md:text-4xl font-bold text-mulearn-blackish mb-4">
                             Your Learning Journey
                         </h2>
-                        <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+                        <p className="text-lg text-mulearn-gray-600 max-w-2xl mx-auto">
                             From curiosity to career readiness in five simple steps
                         </p>
                     </motion.div>
 
                     {/* Desktop Timeline */}
                     <div className="hidden md:block relative">
-                        <div className="absolute left-1/2 top-0 bottom-0 w-0.5 bg-gradient-to-b from-blue-200 via-blue-400 to-blue-600 transform -translate-x-1/2" />
-                        
                         {workflowSteps.map((step, index) => {
                             const Icon = step.icon;
                             const isLeft = index % 2 === 0;
@@ -196,12 +184,12 @@ export default function InterestGroups() {
                                 >
                                     <div className={`flex items-center ${isLeft ? 'justify-end' : 'justify-start'}`}>
                                         <div className={`w-5/12 ${isLeft ? 'pr-12 text-right' : 'pl-12 text-left'}`}>
-                                            <div className="bg-white p-6 rounded-2xl shadow-lg border border-gray-100 hover:shadow-xl transition-shadow duration-300">
+                                            <div className="bg-mulearn-whitish p-6 rounded-2xl shadow-lg border border-mulearn-greyish/20 hover:shadow-xl transition-shadow duration-300">
                                                 <div className={`flex items-center gap-3 mb-3 ${isLeft ? 'justify-end' : 'justify-start'}`}>
-                                                    <Icon className="w-6 h-6 text-blue-600" />
-                                                    <h3 className="text-xl font-bold text-gray-900">{step.title}</h3>
+                                                    <Icon className="w-6 h-6 text-mulearn-trusty-blue" />
+                                                    <h3 className="text-xl font-bold text-mulearn-blackish">{step.title}</h3>
                                                 </div>
-                                                <p className="text-gray-600 leading-relaxed">{step.description}</p>
+                                                <p className="text-mulearn-gray-600 leading-relaxed">{step.description}</p>
                                             </div>
                                         </div>
                                     </div>
@@ -213,9 +201,9 @@ export default function InterestGroups() {
                                             whileInView={{ scale: 1 }}
                                             viewport={{ once: true }}
                                             transition={{ duration: 0.4, delay: index * 0.1 + 0.2 }}
-                                            className="w-12 h-12 bg-blue-600 rounded-full flex items-center justify-center shadow-lg"
+                                            className="w-12 h-12 bg-mulearn-trusty-blue rounded-full flex items-center justify-center shadow-lg"
                                         >
-                                            <div className="w-6 h-6 bg-white rounded-full" />
+                                            <div className="w-6 h-6 bg-mulearn-whitish rounded-full" />
                                         </motion.div>
                                     </div>
                                 </motion.div>
@@ -239,20 +227,20 @@ export default function InterestGroups() {
                                 >
                                     {/* Vertical line */}
                                     {index < workflowSteps.length - 1 && (
-                                        <div className="absolute left-5 top-12 bottom-0 w-0.5 bg-blue-200 transform -translate-x-1/2" />
+                                        <div className="absolute left-5 top-12 bottom-0 w-0.5 bg-mulearn-trusty-blue/30 transform -translate-x-1/2" />
                                     )}
                                     
                                     {/* Dot */}
                                     <div className="absolute left-0 top-0">
-                                        <div className="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center shadow-md">
-                                            <Icon className="w-5 h-5 text-white" />
+                                        <div className="w-10 h-10 bg-mulearn-trusty-blue rounded-full flex items-center justify-center shadow-md">
+                                            <Icon className="w-5 h-5 text-mulearn-whitish" />
                                         </div>
                                     </div>
                                     
                                     {/* Content */}
-                                    <div className="bg-white p-6 rounded-xl shadow-md border border-gray-100">
-                                        <h3 className="text-lg font-bold text-gray-900 mb-2">{step.title}</h3>
-                                        <p className="text-gray-600 text-sm leading-relaxed">{step.description}</p>
+                                    <div className="bg-mulearn-whitish p-6 rounded-xl shadow-md border border-mulearn-greyish/20">
+                                        <h3 className="text-lg font-bold text-mulearn-blackish mb-2">{step.title}</h3>
+                                        <p className="text-mulearn-gray-600 text-sm leading-relaxed">{step.description}</p>
                                     </div>
                                 </motion.div>
                             );
@@ -270,22 +258,22 @@ export default function InterestGroups() {
                     transition={{ duration: 0.8 }}
                     className="text-center mb-12"
                 >
-                    <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+                    <h2 className="text-3xl md:text-4xl font-bold text-mulearn-blackish mb-4">
                         Explore Interest Groups
                     </h2>
-                    <p className="text-lg text-gray-600 max-w-2xl mx-auto mb-8">
+                    <p className="text-lg text-mulearn-gray-600 max-w-2xl mx-auto mb-8">
                         Choose a domain that excites you and start your learning journey today
                     </p>
 
                     {/* Search Bar */}
                     <div className="max-w-md mx-auto relative">
-                        <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
+                        <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-mulearn-gray-600 w-5 h-5" />
                         <input
                             type="text"
                             placeholder="Search interest groups..."
                             value={searchTerm}
                             onChange={(e) => setSearchTerm(e.target.value)}
-                            className="w-full pl-12 pr-4 py-3 rounded-full border-2 border-gray-200 focus:border-blue-500 focus:outline-none transition-colors duration-300 text-gray-900 placeholder-gray-400"
+                            className="w-full pl-12 pr-4 py-3 rounded-full border-2 border-mulearn-greyish/40 focus:border-mulearn-trusty-blue focus:outline-none transition-colors duration-300 text-mulearn-blackish placeholder-mulearn-gray-600/70"
                             aria-label="Search interest groups"
                         />
                     </div>
@@ -305,7 +293,7 @@ export default function InterestGroups() {
                             transition={{ duration: 0.5, delay: index * 0.05 }}
                             className="group block"
                         >
-                            <div className="relative h-full bg-white rounded-2xl shadow-md hover:shadow-2xl transition-all duration-300 overflow-hidden border border-gray-100">
+                            <div className="relative h-full bg-mulearn-whitish rounded-2xl shadow-md hover:shadow-2xl transition-all duration-300 overflow-hidden border border-mulearn-greyish/20">
                                 {/* Image Header - Full width gradient background with centered image */}
                                 <div className="relative h-48 overflow-hidden rounded-t-2xl">
                                     <MuImage
@@ -319,21 +307,21 @@ export default function InterestGroups() {
 
                                 {/* Card Content */}
                                 <div className="relative z-10 flex flex-col p-6">
-                                    <h3 className="text-xl font-bold text-gray-900 mb-2 group-hover:text-blue-600 transition-colors duration-300">
+                                    <h3 className="text-xl font-bold text-mulearn-blackish mb-2 group-hover:text-mulearn-trusty-blue transition-colors duration-300">
                                         {group.name}
                                     </h3>
-                                    <p className="text-sm text-gray-600 mb-4 flex-grow">
+                                    <p className="text-sm text-mulearn-gray-600 mb-4 flex-grow">
                                         {group.tagline}
                                     </p>
                                     
-                                    <div className="flex items-center gap-2 text-blue-600 font-medium text-sm group-hover:gap-3 transition-all duration-300">
+                                    <div className="flex items-center gap-2 text-mulearn-trusty-blue font-medium text-sm group-hover:gap-3 transition-all duration-300">
                                         Explore <ArrowRight className="w-4 h-4" />
                                     </div>
                                 </div>
 
                                 {/* Hover Overlay */}
-                                <div className="absolute inset-0 bg-gradient-to-br from-blue-600 to-indigo-700 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center p-6 z-20 rounded-2xl">
-                                    <p className="text-white text-sm leading-relaxed text-center">
+                                <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center p-6 z-20 rounded-2xl" style={{ background: "var(--mulearn-trusty)" }}>
+                                    <p className="text-mulearn-whitish text-sm leading-relaxed text-center">
                                         {group.description}
                                     </p>
                                 </div>
@@ -348,7 +336,7 @@ export default function InterestGroups() {
                         animate={{ opacity: 1 }}
                         className="text-center py-16"
                     >
-                        <p className="text-gray-500 text-lg">No interest groups found matching your search.</p>
+                        <p className="text-mulearn-gray-600 text-lg">No interest groups found matching your search.</p>
                     </motion.div>
                 )}
             </section>
@@ -362,7 +350,7 @@ export default function InterestGroups() {
                     transition={{ duration: 0.8 }}
                     className="max-w-4xl mx-auto text-center"
                 >
-                    <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
+                    <h2 className="text-3xl md:text-4xl font-bold text-mulearn-whitish mb-6">
                         Ready to Start Your Journey?
                     </h2>
                     <p className="text-lg text-mulearn-whitish/90 mb-8 max-w-2xl mx-auto">

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -147,7 +147,7 @@ export const interestGroups = [
         name: "UI/UX",
         link: "https://app.mulearn.org/dashboard/interestgroups/46fe1fb7-7b04-4ebe-837d-120bc16d0e0a",
         tagline: "Design beautiful, user-friendly experiences",
-        image: cdnUrl("public/assets/landing/design.svg"),
+        image: "/assets/InterestGroups/design.svg",
         description:
             "Master the art of user interface and user experience design. Share portfolios, get feedback, and learn the latest design trends."
     },
@@ -155,7 +155,7 @@ export const interestGroups = [
         name: "Web Development",
         link: "https://app.mulearn.org/dashboard/interestgroups/9b8aaf7f-16a0-4a66-ae53-79b8c25e5faa",
         tagline: "Build the web, shape the world",
-        image: cdnUrl("public/assets/landing/webdev.svg"),
+        image: "/assets/InterestGroups/webdev.svg",
         description:
             "Explore frontend, backend, and full-stack development. Collaborate on real-world web projects and learn modern frameworks."
     },
@@ -163,7 +163,7 @@ export const interestGroups = [
         name: "Cybersecurity",
         link: "https://app.mulearn.org/dashboard/interestgroups/3a74725e-a05a-418b-a275-39d68ad9a416",
         tagline: "Secure the digital frontier",
-        image: cdnUrl("public/assets/landing/cybersecurity.svg"),
+        image: "/assets/InterestGroups/cyber.svg",
         description:
             "Learn how to protect systems and data. Participate in CTFs, workshops, and security challenges."
     },
@@ -171,7 +171,7 @@ export const interestGroups = [
         name: "Game Development",
         link: "https://app.mulearn.org/dashboard/interestgroups/1be43a3a-bcfb-4ef1-b77a-959b01bcb782",
         tagline: "Create immersive gaming experiences",
-        image: cdnUrl("public/assets/landing/game.svg"),
+        image: "/assets/InterestGroups/game.svg",
         description:
             "Dive into game design, development, and storytelling. Collaborate on projects and learn from industry experts."
     },
@@ -179,7 +179,7 @@ export const interestGroups = [
         name: "Internet Of Things (IOT) And Robotics",
         link: "https://app.mulearn.org/dashboard/interestgroups/d379d82b-e116-4b67-8128-670916e6bb42",
         tagline: "Connect the world, automate the future",
-        image: cdnUrl("public/assets/landing/iot.svg"),
+        image: "/assets/InterestGroups/iot.svg",
         description:
             "Explore IoT devices, robotics, and automation. Build smart systems and learn about hardware integration."
     },
@@ -187,7 +187,7 @@ export const interestGroups = [
         name: "Digital Marketing",
         link: "https://app.mulearn.org/dashboard/interestgroups/5bf2bdfe-5c22-48ab-9572-9e9836c70e79",
         tagline: "Grow brands in the digital age",
-        image: cdnUrl("public/assets/landing/marketing.svg"),
+        image: "/assets/InterestGroups/marketing.svg",
         description:
             "Master SEO, social media, and online campaigns. Learn strategies to boost engagement and reach."
     },
@@ -195,7 +195,7 @@ export const interestGroups = [
         name: "Cloud and DevOps",
         link: "https://app.mulearn.org/dashboard/interestgroups/1719d19a-0206-4161-9c6f-0a7dba44d4e5",
         tagline: "Deploy, scale, and automate",
-        image: cdnUrl("public/assets/landing/cloud.svg"),
+        image: "/assets/InterestGroups/cloud.svg",
         description:
             "Learn cloud platforms, CI/CD, and infrastructure automation. Collaborate on scalable solutions."
     },
@@ -203,7 +203,7 @@ export const interestGroups = [
         name: "Product Management",
         link: "https://app.mulearn.org/dashboard/interestgroups/04d29c15-4de4-4b43-ad63-0f4760c62919",
         tagline: "Build products people love",
-        image: cdnUrl("public/assets/landing/product.svg"),
+        image: "/assets/InterestGroups/product.svg",
         description:
             "Discover the art of product strategy, development, and launch. Work with teams to deliver impactful solutions."
     },
@@ -211,7 +211,7 @@ export const interestGroups = [
         name: "Entrepreneurship",
         link: "https://app.mulearn.org/dashboard/interestgroups/243a1bda-893c-4de3-b457-51e7cb517d83",
         tagline: "Turn ideas into reality",
-        image: cdnUrl("public/assets/landing/entrepreneurship.svg"),
+        image: "/assets/InterestGroups/entrepreneurship.svg",
         description:
             "Learn how to start, grow, and scale ventures. Connect with founders and innovators."
     },
@@ -219,7 +219,7 @@ export const interestGroups = [
         name: "AR/VR",
         link: "https://app.mulearn.org/dashboard/interestgroups/2de0ee0c-ddc3-4f02-bf93-b6bd2d0625c3",
         tagline: "Experience the future in 3D",
-        image: cdnUrl("public/assets/landing/arvr.svg"),
+        image: "/assets/InterestGroups/arvr.svg",
         description:
             "Explore augmented and virtual reality. Build immersive applications and learn cutting-edge tech."
     }

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -67,7 +67,7 @@ export const navItems = [
       Explore: [
         {
           label: "Interest Groups",
-          href: "https://app.mulearn.org/dashboard/interestgroups",
+          href: "/interest-groups",
         },
         {
           label: "Learning Circle",
@@ -114,7 +114,7 @@ export const features = [
     ),
     bgColor: "#5ce5c9",
     cta: "Explore IGs",
-    url: "/interestgroups",
+    url: "/interest-groups",
   },
   {
     title: "Roadmaps",
@@ -140,6 +140,89 @@ export const features = [
     cta: "See Opportunities",
     url: "/careers",
   },
+];
+
+export const interestGroups = [
+    {
+        name: "UI/UX",
+        link: "https://app.mulearn.org/dashboard/interestgroups/46fe1fb7-7b04-4ebe-837d-120bc16d0e0a",
+        tagline: "Design beautiful, user-friendly experiences",
+        image: cdnUrl("public/assets/landing/design.svg"),
+        description:
+            "Master the art of user interface and user experience design. Share portfolios, get feedback, and learn the latest design trends."
+    },
+    {
+        name: "Web Development",
+        link: "https://app.mulearn.org/dashboard/interestgroups/9b8aaf7f-16a0-4a66-ae53-79b8c25e5faa",
+        tagline: "Build the web, shape the world",
+        image: cdnUrl("public/assets/landing/webdev.svg"),
+        description:
+            "Explore frontend, backend, and full-stack development. Collaborate on real-world web projects and learn modern frameworks."
+    },
+    {
+        name: "Cybersecurity",
+        link: "https://app.mulearn.org/dashboard/interestgroups/3a74725e-a05a-418b-a275-39d68ad9a416",
+        tagline: "Secure the digital frontier",
+        image: cdnUrl("public/assets/landing/cybersecurity.svg"),
+        description:
+            "Learn how to protect systems and data. Participate in CTFs, workshops, and security challenges."
+    },
+    {
+        name: "Game Development",
+        link: "https://app.mulearn.org/dashboard/interestgroups/1be43a3a-bcfb-4ef1-b77a-959b01bcb782",
+        tagline: "Create immersive gaming experiences",
+        image: cdnUrl("public/assets/landing/game.svg"),
+        description:
+            "Dive into game design, development, and storytelling. Collaborate on projects and learn from industry experts."
+    },
+    {
+        name: "Internet Of Things (IOT) And Robotics",
+        link: "https://app.mulearn.org/dashboard/interestgroups/d379d82b-e116-4b67-8128-670916e6bb42",
+        tagline: "Connect the world, automate the future",
+        image: cdnUrl("public/assets/landing/iot.svg"),
+        description:
+            "Explore IoT devices, robotics, and automation. Build smart systems and learn about hardware integration."
+    },
+    {
+        name: "Digital Marketing",
+        link: "https://app.mulearn.org/dashboard/interestgroups/5bf2bdfe-5c22-48ab-9572-9e9836c70e79",
+        tagline: "Grow brands in the digital age",
+        image: cdnUrl("public/assets/landing/marketing.svg"),
+        description:
+            "Master SEO, social media, and online campaigns. Learn strategies to boost engagement and reach."
+    },
+    {
+        name: "Cloud and DevOps",
+        link: "https://app.mulearn.org/dashboard/interestgroups/1719d19a-0206-4161-9c6f-0a7dba44d4e5",
+        tagline: "Deploy, scale, and automate",
+        image: cdnUrl("public/assets/landing/cloud.svg"),
+        description:
+            "Learn cloud platforms, CI/CD, and infrastructure automation. Collaborate on scalable solutions."
+    },
+    {
+        name: "Product Management",
+        link: "https://app.mulearn.org/dashboard/interestgroups/04d29c15-4de4-4b43-ad63-0f4760c62919",
+        tagline: "Build products people love",
+        image: cdnUrl("public/assets/landing/product.svg"),
+        description:
+            "Discover the art of product strategy, development, and launch. Work with teams to deliver impactful solutions."
+    },
+    {
+        name: "Entrepreneurship",
+        link: "https://app.mulearn.org/dashboard/interestgroups/243a1bda-893c-4de3-b457-51e7cb517d83",
+        tagline: "Turn ideas into reality",
+        image: cdnUrl("public/assets/landing/entrepreneurship.svg"),
+        description:
+            "Learn how to start, grow, and scale ventures. Connect with founders and innovators."
+    },
+    {
+        name: "AR/VR",
+        link: "https://app.mulearn.org/dashboard/interestgroups/2de0ee0c-ddc3-4f02-bf93-b6bd2d0625c3",
+        tagline: "Experience the future in 3D",
+        image: cdnUrl("public/assets/landing/arvr.svg"),
+        description:
+            "Explore augmented and virtual reality. Build immersive applications and learn cutting-edge tech."
+    }
 ];
 
 export const specialevents = [
@@ -459,7 +542,7 @@ export const footer = [
       { title: "Career Labs", url: "/careers" },
       {
         title: "Interest Groups",
-        url: "https://app.mulearn.org/dashboard/interestgroups",
+        url: "/interest-groups",
       },
       { title: "Donate", url: "/donate" },
     ],


### PR DESCRIPTION
This pull request updates navigation and feature URLs for Interest Groups to use internal routes and introduces a new `interestGroups` data structure with detailed information for each group. These changes improve consistency and make it easier to display Interest Groups across the site.

**Navigation and URL consistency:**

* Updated Interest Groups links in `navItems`, `features`, and `footer` to use the internal route `/interest-groups` instead of an external dashboard URL. [[1]](diffhunk://#diff-6d286725acbd5d2ec188a6f5bd83105f4e306fdb3cc44abc8309e779d0215c6aL70-R70) [[2]](diffhunk://#diff-6d286725acbd5d2ec188a6f5bd83105f4e306fdb3cc44abc8309e779d0215c6aL117-R117) [[3]](diffhunk://#diff-6d286725acbd5d2ec188a6f5bd83105f4e306fdb3cc44abc8309e779d0215c6aL462-R545)

**Interest Groups data structure:**

* Added a new `interestGroups` array to `data.ts`, containing detailed info (name, tagline, image, description, and external link) for each Interest Group, enabling richer content and easier display on the site.